### PR TITLE
Install ntp

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -8,6 +8,8 @@
       "fonts-vlgothic",
       "jq",
       "kolourpaint4",
+      "ntp",
+      "ntpdate",
       "plasma-widget-folderview",
       "sudo",
       "vlc",


### PR DESCRIPTION
On Debian Jessie it is not installed by default